### PR TITLE
fix(cpanfile): corrige versões e adiciona dependências faltando

### DIFF
--- a/api/cpanfile
+++ b/api/cpanfile
@@ -1,2 +1,2 @@
-requires 'Mojolicious', '9.42';
-requires 'Mojo::Pg', '4.29';
+requires 'Mojolicious', '9.45';
+requires 'Mojo::Pg',    '5.0';

--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,7 @@
-requires 'Digest::MD5',     '2.59';
-requires 'DBIx::Custom',    '0.45';
-requires 'WWW::Mechanize', '2.21';
-requires 'Mojo::Util', '9.46';
+requires 'Digest::MD5',    '2.59';
+requires 'DBIx::Custom',   '0.45';
+requires 'WWW::Mechanize', '2.22';
+requires 'Mojolicious',    '9.45';
+requires 'LWP::UserAgent', '6.83';
+requires 'JSON',           '4.11';
+requires 'Config::Simple', '4.58';

--- a/engine/cpanfile
+++ b/engine/cpanfile
@@ -1,1 +1,1 @@
-requires "";
+requires 'Find::Lib', '1.04';


### PR DESCRIPTION
## Resumo

- **`cpanfile` (crawlers):** substitui `Mojo::Util 9.46` (versão inexistente no CPAN) por `Mojolicious 9.45`; atualiza `WWW::Mechanize` para `2.22`; adiciona `LWP::UserAgent 6.83`, `JSON 4.11` e `Config::Simple 4.58` que estavam em uso mas não declarados
- **`engine/cpanfile`:** substitui `requires ""` inválido por `Find::Lib 1.04` (usado em `engine/app.pl`)
- **`api/cpanfile`:** atualiza `Mojolicious 9.42 → 9.45` e `Mojo::Pg 4.29 → 5.0`

## Causa do erro de instalação

`requires 'Mojo::Util', '9.46'` no `cpanfile` raiz pedia uma versão que não existe — `Mojo::Util` faz parte do `Mojolicious`, cuja última versão é `9.45`.

## Versões no CPAN

| Módulo | Versão anterior | Versão atual (CPAN) |
|---|---|---|
| `Mojolicious` | `9.42` | `9.45` |
| `Mojo::Pg` | `4.29` | `5.0` |
| `WWW::Mechanize` | `2.21` | `2.22` |
| `Digest::MD5` | `2.59` | `2.59` ✓ |
| `DBIx::Custom` | `0.45` | `0.45` ✓ |
| `LWP::UserAgent` | *(faltava)* | `6.83` |
| `JSON` | *(faltava)* | `4.11` |
| `Config::Simple` | *(faltava)* | `4.58` |
| `Find::Lib` | *(faltava)* | `1.04` |

> **Nota:** `Mojo::Pg 5.0` exige Perl >= 5.20. O projeto tem arquivos com `use 5.018` — verifique a versão do Perl no ambiente antes de mergear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQ8bcjvJiwybKbsNkhNbzM

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQ8bcjvJiwybKbsNkhNbzM)_